### PR TITLE
유저 관련 API 연결 (로그인, 회원가입, 회원정보 조회), 비밀번호 수정/취소 모드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"react-router-dom": "^6.11.1",
 				"react-scripts": "5.0.1",
 				"recoil": "^0.7.7",
+				"recoil-persist": "^4.2.0",
 				"typescript": "^4.9.5",
 				"web-vitals": "^2.1.4"
 			}
@@ -15555,6 +15556,14 @@
 				"react-native": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/recoil-persist": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+			"integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+			"peerDependencies": {
+				"recoil": "^0.7.2"
 			}
 		},
 		"node_modules/recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"react-router-dom": "^6.11.1",
 		"react-scripts": "5.0.1",
 		"recoil": "^0.7.7",
+		"recoil-persist": "^4.2.0",
 		"typescript": "^4.9.5",
 		"web-vitals": "^2.1.4"
 	},

--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+const baseUrl = process.env.REACT_APP_API_BASE_URL;

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+const baseUrl = process.env.REACT_APP_API_BASE_URL;
+
+export type UserFormType = {
+	userEmail: string;
+	password: string;
+	nickname: string;
+};
+
+export const registerUser = async (formData: UserFormType) => {
+	const response = await axios.post(`${baseUrl}/users`, formData);
+	return response;
+};

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -2,13 +2,25 @@ import axios from 'axios';
 
 const baseUrl = process.env.REACT_APP_API_BASE_URL;
 
-export type UserFormType = {
+//회원가입 : Start
+export type RegisterFormType = {
 	userEmail: string;
 	password: string;
 	nickname: string;
 };
-
-export const registerUser = async (formData: UserFormType) => {
+export const registerUser = async (formData: RegisterFormType) => {
 	const response = await axios.post(`${baseUrl}/users`, formData);
 	return response;
 };
+//회원가입 : End
+
+//로그인 : Start
+export type LoginFormType = {
+	userEmail: string;
+	password: string;
+};
+export const loginUser = async (formData: LoginFormType) => {
+	const response = await axios.post(`${baseUrl}/auth/login`, formData);
+	return response;
+};
+//로그인 : End

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -24,3 +24,14 @@ export const loginUser = async (formData: LoginFormType) => {
 	return response;
 };
 //로그인 : End
+
+//회원 정보 조회 : Start
+export const infoUser = async (token: string) => {
+	const response = await axios.get(`${baseUrl}/users/me`, {
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+	});
+	return response;
+};
+//회원 정보 조회 : End

--- a/src/apis/word.ts
+++ b/src/apis/word.ts
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+const baseUrl = process.env.REACT_APP_API_BASE_URL;

--- a/src/hooks/useUserValidator.ts
+++ b/src/hooks/useUserValidator.ts
@@ -8,7 +8,7 @@ type ValuesProps = {
 };
 
 function useUserValidator(values: ValuesProps) {
-	const [errors, setErrors] = useState<{ [x: string]: string }>(values);
+	const [errors, setErrors] = useState<ValuesProps>(values);
 	const [validationPass, setValidationPass] = useState<boolean>(false);
 	const [submitAttempt, setSubmitAttempt] = useState<boolean>(false);
 

--- a/src/hooks/useUserValidator.ts
+++ b/src/hooks/useUserValidator.ts
@@ -131,7 +131,14 @@ function useUserValidator(values: ValuesProps) {
 		}
 	}, [submitAttempt, errors]);
 
-	return { errors, setErrors, userValidator, setSubmitAttempt, validationPass };
+	return {
+		errors,
+		setErrors,
+		userValidator,
+		setSubmitAttempt,
+		validationPass,
+		setValidationPass,
+	};
 }
 
 export default useUserValidator;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -97,7 +97,8 @@ function Login() {
 							onClick={e => {
 								e.preventDefault();
 								userValidator(values, true);
-							}}>
+							}}
+						>
 							로그인
 						</UserButton>
 					</li>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { AxiosError } from 'axios';
 import useUserValidator from '../hooks/useUserValidator';
+import { registerUser } from '../apis/user';
 import styles from '../components/User/Register.module.scss';
 import Logo from '../components/common/Logo/Logo';
 import UserInput from '../components/User/UserInput/UserInput';
 import UserButton from '../components/User/UserButton/UserButton';
 
 function Register() {
+	const navigate = useNavigate();
 	const logoStyle = {
 		transform: 'translateX(-10px)',
 		marginBottom: '5vh',
@@ -20,11 +24,45 @@ function Register() {
 
 	const [values, setValues] = useState(initValues);
 
-	const { errors, setErrors, userValidator, validationPass } =
-		useUserValidator(initValues);
+	const {
+		errors,
+		setErrors,
+		userValidator,
+		validationPass,
+		setValidationPass,
+	} = useUserValidator(initValues);
+
+	const handleSubmit = async () => {
+		try {
+			const data = {
+				userEmail: values.email,
+				password: values.password,
+				nickname: values.nickname,
+			};
+			const response = await registerUser(data);
+			if (response.status === 200) {
+				alert('회원가입에 성공하였습니다. 로그인해주세요.');
+				navigate('/login');
+			}
+		} catch (err: unknown) {
+			if (err instanceof AxiosError) {
+				if (err.response?.status === 409) {
+					const errMsg = err.response.data.reason;
+					return setErrors(prev => ({ ...prev, email: errMsg }));
+				}
+			}
+
+			//console.log(err);
+			alert('회원가입에 실패하였습니다.');
+		}
+	};
 
 	useEffect(() => {
-		if (validationPass) alert('유효성 검사 통과!!!');
+		if (validationPass) {
+			handleSubmit();
+			//유효성 검사 성공 여부 초기화
+			setValidationPass(false);
+		}
 	}, [validationPass]);
 
 	return (

--- a/src/pages/UserEdit.tsx
+++ b/src/pages/UserEdit.tsx
@@ -103,14 +103,14 @@ function UserEdit() {
 						</>
 					)}
 					{!passwordEdit && (
-						<li>
+						<li style={{ marginBottom: '10px' }}>
 							<UserButton onClick={() => switchEditMode(true)}>
 								비밀번호 수정
 							</UserButton>
 						</li>
 					)}
 					{passwordEdit && (
-						<li>
+						<li style={{ marginBottom: '10px' }}>
 							<UserButton onClick={() => switchEditMode(false)}>
 								비밀번호 수정 취소
 							</UserButton>

--- a/src/pages/UserEdit.tsx
+++ b/src/pages/UserEdit.tsx
@@ -5,6 +5,12 @@ import Logo from '../components/common/Logo/Logo';
 import UserInput from '../components/User/UserInput/UserInput';
 import UserButton from '../components/User/UserButton/UserButton';
 
+type ValuesProps = {
+	nickname: string;
+	password?: string;
+	passwordConfirm?: string;
+};
+
 function UserEdit() {
 	const logoStyle = {
 		transform: 'translateX(-10px)',
@@ -13,13 +19,36 @@ function UserEdit() {
 
 	const initValues = {
 		nickname: '',
-		password: '',
-		passwordConfirm: '',
 	};
 
-	const [values, setValues] = useState(initValues);
-	const { errors, userValidator, validationPass } =
+	const [values, setValues] = useState<ValuesProps>(initValues);
+	const [passwordEdit, setPasswordEdit] = useState<boolean>(false);
+	const { errors, setErrors, userValidator, validationPass } =
 		useUserValidator(initValues);
+
+	const switchEditMode = (isPasswordEdit: boolean): void => {
+		if (isPasswordEdit) {
+			//비밀번호 수정 가능 모드로 변환
+			const passwordValues = {
+				password: '',
+				passwordConfirm: '',
+			};
+			setPasswordEdit(isPasswordEdit);
+			setValues(prev => ({ ...prev, ...passwordValues }));
+			setErrors(prev => ({ ...prev, ...passwordValues }));
+		} else {
+			//닉네임만 수정 가능 모드로 변환
+			setPasswordEdit(isPasswordEdit);
+			setValues(prev => {
+				const { password, passwordConfirm, ...rest } = prev;
+				return rest;
+			});
+			setErrors(prev => {
+				const { password, passwordConfirm, ...rest } = prev;
+				return rest;
+			});
+		}
+	};
 
 	useEffect(() => {
 		if (validationPass) alert('유효성 검사 통과!!!');
@@ -50,25 +79,43 @@ function UserEdit() {
 							error={errors.nickname}
 						/>
 					</li>
-					<li>
-						<UserInput
-							type='password'
-							name='password'
-							label='비밀번호'
-							setValues={setValues}
-							condition='8자 이상 (대소문자, 특수 문자, 숫자 포함)'
-							error={errors.password}
-						/>
-					</li>
-					<li>
-						<UserInput
-							type='password'
-							name='passwordConfirm'
-							label='비밀번호 확인'
-							setValues={setValues}
-							error={errors.passwordConfirm}
-						/>
-					</li>
+					{passwordEdit && (
+						<>
+							<li>
+								<UserInput
+									type='password'
+									name='password'
+									label='비밀번호'
+									setValues={setValues}
+									condition='8자 이상 (대소문자, 특수 문자, 숫자 포함)'
+									error={errors.password}
+								/>
+							</li>
+							<li>
+								<UserInput
+									type='password'
+									name='passwordConfirm'
+									label='비밀번호 확인'
+									setValues={setValues}
+									error={errors.passwordConfirm}
+								/>
+							</li>
+						</>
+					)}
+					{!passwordEdit && (
+						<li>
+							<UserButton onClick={() => switchEditMode(true)}>
+								비밀번호 수정
+							</UserButton>
+						</li>
+					)}
+					{passwordEdit && (
+						<li>
+							<UserButton onClick={() => switchEditMode(false)}>
+								비밀번호 수정 취소
+							</UserButton>
+						</li>
+					)}
 					<li>
 						<UserButton
 							type='submit'

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -1,14 +1,52 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+import { AxiosError } from 'axios';
+import { useRecoilValue } from 'recoil';
+import { infoUser } from '../apis/user';
+import { userTokenState } from '../recoil/userState';
 import styles from '../components/User/UserInfo.module.scss';
 import Logo from '../components/common/Logo/Logo';
 import UserButton from '../components/User/UserButton/UserButton';
 import { SiRabbitmq } from 'react-icons/si';
 
 function UserInfo() {
+	const navigate = useNavigate();
+	const userToken = useRecoilValue(userTokenState);
+	const [userInfo, setUserInfo] = useState({
+		email: '',
+		nickname: '',
+	});
+
 	const logoStyle = {
 		transform: 'translateX(-10px)',
 		marginBottom: '5vh',
 	};
+
+	const getUserInfo = async () => {
+		try {
+			const response = await infoUser(userToken);
+			const { userEmail, nickname } = response.data;
+			if (response.status === 200) {
+				setUserInfo({
+					email: userEmail,
+					nickname,
+				});
+			}
+		} catch (err: unknown) {
+			if (err instanceof AxiosError) {
+				if (err.response?.status === 401) {
+					return navigate('/login');
+				}
+			}
+
+			//console.log(err);
+			alert('회원 정보를 불러오는데 실패하였습니다.');
+		}
+	};
+
+	useEffect(() => {
+		getUserInfo();
+	}, []);
 
 	return (
 		<main className={styles.container}>
@@ -19,14 +57,14 @@ function UserInfo() {
 						<SiRabbitmq />
 						이메일
 					</span>
-					elice@email.com
+					{userInfo.email && userInfo.email}
 				</li>
 				<li>
 					<span>
 						<SiRabbitmq />
 						닉네임
 					</span>
-					엘리스
+					{userInfo.nickname && userInfo.nickname}
 				</li>
 				<li>
 					<UserButton type='link' path='/user/edit'>

--- a/src/recoil/userState.ts
+++ b/src/recoil/userState.ts
@@ -1,0 +1,6 @@
+import { atom, selector } from 'recoil';
+
+export const userTokenState = atom({
+	key: 'userToken',
+	default: null,
+});

--- a/src/recoil/userState.ts
+++ b/src/recoil/userState.ts
@@ -1,6 +1,13 @@
 import { atom, selector } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist({
+	key: 'persistUserToken',
+	storage: sessionStorage,
+});
 
 export const userTokenState = atom({
 	key: 'userToken',
-	default: null,
+	default: '',
+	effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
## 개요
- 로그인, 회원가입, 회원정보 조회 기능 추가
- 회원정보 수정 페이지 비밀번호 수정/취소 모드 추가
- API 폴더 분리
- recoil-persist 설치 및 적용
- 유저 토큰 recoil state로 저장
- gitignore에 .env 추가

## 작업사항
- Register 페이지 회원가입 API 연결 및 에러 처리
- Login 페이지 로그인 API 연결 및 에러 처리 (발급 받은 토큰 recoil state로 저장)
- UserInfo 페이지 회원 정보 조회 API 연결 및 에러 처리
- UserInfo 페이지 버튼 클릭시 비밀번호 수정/취소 모드 변환
- redux-persist 설치 및 적용
- src/apis 폴더에 API 연결 함수 분리 (권장)